### PR TITLE
Preserve the os environment when calling phantomjs

### DIFF
--- a/phantomjs.go
+++ b/phantomjs.go
@@ -88,7 +88,8 @@ func (p *Process) Open() error {
 
 		// Start external process.
 		cmd := exec.Command(p.BinPath, "--local-to-remote-url-access=true", fmt.Sprintf("--ignore-ssl-errors=%v", p.IgnoreSslErrors), scriptPath) // Yeah, I know right? Fuck Phantomjs
-		cmd.Env = []string{fmt.Sprintf("PORT=%d", p.Port)}
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, fmt.Sprintf("PORT=%d", p.Port))
 		cmd.Stdout = p.Stdout
 		cmd.Stderr = p.Stderr
 		if err := cmd.Start(); err != nil {


### PR DESCRIPTION
If you use Xvfb with phantomjs, it fails to run in this wrapper because the OS environment isn't preserved. Phantomjs needs at least the `DISPLAY` variable to work with Xvfb -- without it, this happens:

```
QXcbConnection: Could not connect to display
PhantomJS has crashed. Please read the bug reporting guide at
<http://phantomjs.org/bug-reporting.html> and file a bug report.
```

This is fixed by simply appending the `PORT` variable onto the existing environment prior to execution.